### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fsmegainfo.yml
+++ b/.github/workflows/fsmegainfo.yml
@@ -31,6 +31,7 @@ jobs:
             || (test -r Tests/test-suite.log && cat Tests/test-suite.log) \
             || (test -r config.log && cat config.log)
     strategy:
+      fail-fast: false
       matrix:
         compiler:
           - clang

--- a/.github/workflows/fsmegainfo.yml
+++ b/.github/workflows/fsmegainfo.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 jobs:
   test:
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - name: checkout
         uses: actions/checkout@v6

--- a/.github/workflows/fsmegainfo.yml
+++ b/.github/workflows/fsmegainfo.yml
@@ -1,5 +1,7 @@
 ---
 name: cooljeanius/FSMegaInfo
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/fsmegainfo.yml
+++ b/.github/workflows/fsmegainfo.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   test:
     runs-on: macos-latest
+    env:
+      CC: ${{ matrix.compiler }}
+      OBJC: ${{ matrix.compiler }}
     steps:
       - name: checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/FSMegaInfo/security/code-scanning/2](https://github.com/cooljeanius/FSMegaInfo/security/code-scanning/2)

To fix the problem, explicitly define a minimal `permissions:` block so the `GITHUB_TOKEN` used by this workflow is restricted to the least privilege required. Since this workflow only checks out code and runs local build/test commands, it only needs read access to repository contents.

The best fix is to add a `permissions:` block at the workflow (top) level, right after `name:` and before `on:`. This way, the restriction applies to all jobs in this workflow, including `test`, without modifying job behavior. Set `contents: read` as suggested by CodeQL, which allows `actions/checkout` to function but prevents the token from performing write operations to the repository or other resources.

Concretely, in `.github/workflows/fsmegainfo.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 2 (`name: cooljeanius/FSMegaInfo`) and line 3 (`on:`). No imports or additional methods are needed, as this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
